### PR TITLE
Improve playback controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "rauschen"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "crossterm 0.23.0",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rauschen"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "ASMR Sound Generator"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,4 @@
-use crate::inputs::key::Key;
+use crate::{inputs::key::Key};
 
 use self::{
     actions::{Action, Actions},
@@ -28,6 +28,7 @@ impl App {
     pub fn new() -> Self {
         let actions = vec![Action::Quit, Action::VolumeUp, Action::VolumeDown].into();
         let state = AppState::initialized();
+
         Self { actions, state }
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -7,6 +7,14 @@ use crate::playback::{self, PlaybackControl};
 
 use super::random_signal::RandomSignal;
 
+macro_rules! log_error {
+    ($fmt:expr) => {{
+        if let Err(err) = $fmt {
+            error!("{}", err.to_string());
+        }
+    }};
+}
+
 pub enum AppState {
     Init,
     Initialized {
@@ -24,9 +32,7 @@ impl AppState {
         let sparkline_data =  signal.by_ref().take(200).collect::<Vec<u64>>();
 
         let playback_remote = playback::start_playback();
-        if let Err(err) = playback_remote.send(PlaybackControl::VolumeUp(current_volume)) {
-            error!("{}", err);
-        }
+        log_error!(playback_remote.send(PlaybackControl::VolumeUp(current_volume)));
 
         Self::Initialized {
             volume: current_volume,
@@ -46,9 +52,7 @@ impl AppState {
             if volume >= &mut 1.0 {
                 *volume = 1.0;
             }
-            if let Err(err) = playback_remote.send(PlaybackControl::VolumeUp(volume.to_owned())) {
-                error!("{}", err);
-            }
+            log_error!(playback_remote.send(PlaybackControl::VolumeUp(volume.to_owned())));
         }
     }
 
@@ -58,9 +62,7 @@ impl AppState {
             if volume.clone() - step >= step {
                 *volume -= step;
             }
-            if let Err(err) = playback_remote.send(PlaybackControl::VolumeDown(volume.to_owned())) {
-                error!("{}", err);
-            }
+            log_error!(playback_remote.send(PlaybackControl::VolumeDown(volume.to_owned())));
         }
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -18,6 +18,9 @@ impl AppState {
         let current_volume = 100;
         let sparkline_data =  signal.by_ref().take(200).collect::<Vec<u64>>();
 
+        playback::start_playback();
+        playback::set_cmd(current_volume);
+
         Self::Initialized {
             volume: current_volume,
             signal,

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -19,10 +19,13 @@ where
         .constraints([Constraint::Length(3), Constraint::Min(10)].as_ref())
         .split(size);
 
+
+    let volume_level = app.state().volume().unwrap() * 100.00;
+
     let gauge = Gauge::default()
         .block(Block::default().title("Volume").borders(Borders::ALL))
         .gauge_style(Style::default().fg(Color::Yellow))
-        .percent(app.state().volume().unwrap());
+        .percent(volume_level as u16);
     rect.render_widget(gauge, chunks[0]);
 
     let sparkline = Sparkline::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,6 @@ pub fn start_ui(app: Rc<RefCell<App>>) -> Result<()> {
     // User event handler
     let tick_rate = Duration::from_millis(200);
     let events = Events::new(tick_rate);
-    playback::start_playback();
-    playback::set_cmd(app.borrow().state().volume().unwrap());
 
     loop {
         let mut app = app.borrow_mut();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,9 @@ use std::fs::File;
 use std::rc::Rc;
 use std::time::Duration;
 
-use std::io::{self, stdout, Cursor};
+use std::io::{stdout, Cursor};
 
 use log::{error, LevelFilter};
-use log4rs::append::file::FileAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
 use tui::backend::CrosstermBackend;


### PR DESCRIPTION
This PR ships with more sophisticated playback controls. Before, we only could control playback via specific integers being sent back and forth.

Now we can send specific commands via Enum, allowing more fine-grained volume control. 