### PR TITLE
Fixes stopped playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "rauschen"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "crossterm 0.23.0",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rauschen"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "ASMR Sound Generator"
 license = "MIT"

--- a/src/playback.rs
+++ b/src/playback.rs
@@ -5,8 +5,8 @@ use std::{
     thread,
 };
 
-use log::error;
-use rodio::{Decoder, OutputStream, Sink};
+use log::{error, debug};
+use rodio::{Decoder, OutputStream, Sink, Source};
 
 use crate::home;
 
@@ -34,6 +34,7 @@ pub fn start_playback() -> Sender<PlaybackControl> {
 
         loop {
             if sink.empty() {
+                debug!("Sink is empty");
                 let file = File::open(filename.clone()).map_err(|err| {
                     error!("{}", err.to_string());
                     panic!("{}", err)
@@ -42,6 +43,7 @@ pub fn start_playback() -> Sender<PlaybackControl> {
                 .unwrap();
 
                 let source = Decoder::new(file)
+                .and_then(|source| Ok(source.repeat_infinite()))
                 .and_then(|source| Ok(sink.append(source)));
                 if let Err(error) = source {
                     error!("{}", error.to_string());


### PR DESCRIPTION
Before, we had the situation that the file playback would stop
eventually and wouldn't immediately pick up again because the loop is
blocked by the receiver.
Now, we have the sink play the file indefinitely.